### PR TITLE
remove diar result files when done

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -3,5 +3,8 @@
 to build as a docker container
 ### `./backend.sh build`
 
-to run said container
+to build only a specified service as a docker container
+### `./backend.sh build {service}`
+
+to run all containers
 ### `./backend.sh run`

--- a/backend/diarization/app/combine.py
+++ b/backend/diarization/app/combine.py
@@ -1,9 +1,9 @@
+import app.util as ut
 import os
 
 def segments_overlap(seg1: list, seg2: list) -> bool:
     """Check if two segments overlap."""
     return seg1["start"] < seg2["start"] + seg2["duration"] and seg1["start"] + seg1["duration"] > seg2["start"]
-
 
 def align_segments_with_overlap_info(transcript_segments: dict, diarization_segments: dict) -> dict:
     combined_segments = []
@@ -63,8 +63,7 @@ def align_segments_with_overlap_info(transcript_segments: dict, diarization_segm
 
 # Adjusting the parse_rttm function to read from a file
 def parse_rttm_from_file(file_path: str) -> dict:
-    file_name, _ = os.path.splitext(os.path.basename(file_path))
-    rttm_path = f"/diarization/config/oracle_vad/pred_rttms/{file_name}.rttm" # TODO make this nicer
+    rttm_path = ut.get_rttm_path(ut.get_file_name(file_path))
     segments = []
     with open(rttm_path, 'r', encoding="utf-8") as f:
         for line in f:
@@ -74,4 +73,3 @@ def parse_rttm_from_file(file_path: str) -> dict:
             speaker = parts[7] if "speaker" in parts[7] else None
             segments.append({"start": start, "duration": duration, "text": text, "speaker": speaker})
     return segments
-

--- a/backend/diarization/app/diarize.py
+++ b/backend/diarization/app/diarize.py
@@ -17,11 +17,6 @@ import wget
 import sys
 import os
 
-os.makedirs(ut.CONFIG_DIR, exist_ok=True)
-os.makedirs(ut.DIARIZE_TMP_DIR, exist_ok=True)
-os.makedirs(ut.OUTPUT_DIR, exist_ok=True)
-
-
 def convert_to_wav(file_path: str, output_path: str):
     """Converts audio file to .wav format."""
     subprocess.call(['ffmpeg', '-hide_banner', '-loglevel', 'warning', '-i', file_path, output_path])

--- a/backend/diarization/app/main.py
+++ b/backend/diarization/app/main.py
@@ -5,9 +5,6 @@ import json
 import os
 from fastapi import FastAPI, HTTPException, status, UploadFile, Form
 
-TMP_DIR = "/tmp"
-os.makedirs(TMP_DIR, exist_ok=True)
-
 app = FastAPI()
 
 @app.post("/diarize", status_code=status.HTTP_201_CREATED)
@@ -16,7 +13,9 @@ async def diarize_media_file(json_data: str = Form(...), file: UploadFile = Form
     if transcription is None:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Transcription data not in request body") # TODO should this be a error?
 
-    file_path = os.path.join(TMP_DIR, file.filename)
+    ut.initialize_dirs()
+
+    file_path = os.path.join(ut.TMP_DIR, file.filename)
 
     # Temporary save the uploaded media locally
     with open(file_path, "wb") as media_file:
@@ -29,10 +28,7 @@ async def diarize_media_file(json_data: str = Form(...), file: UploadFile = Form
     except Exception:
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Diarization error.")
     finally:
-        # Remove temp files
-        os.remove(ut.get_rttm_path(ut.get_file_name(file_path)))
-        os.remove(ut.get_wav_path(ut.get_file_name(file_path)))
-        os.remove(file_path)
+        ut.delete_dirs()
 
     return {"diarization": transcription}
     

--- a/backend/diarization/app/main.py
+++ b/backend/diarization/app/main.py
@@ -1,5 +1,6 @@
 import app.diarize as di
 import app.combine as co
+import app.util as ut
 import json
 import os
 from fastapi import FastAPI, HTTPException, status, UploadFile, Form
@@ -8,7 +9,6 @@ TMP_DIR = "/tmp"
 os.makedirs(TMP_DIR, exist_ok=True)
 
 app = FastAPI()
-
 
 @app.post("/diarize", status_code=status.HTTP_201_CREATED)
 async def diarize_media_file(json_data: str = Form(...), file: UploadFile = Form(...)):
@@ -29,7 +29,9 @@ async def diarize_media_file(json_data: str = Form(...), file: UploadFile = Form
     except Exception:
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Diarization error.")
     finally:
-        # Remove temp file
+        # Remove temp files
+        os.remove(ut.get_rttm_path(ut.get_file_name(file_path)))
+        os.remove(ut.get_wav_path(ut.get_file_name(file_path)))
         os.remove(file_path)
 
     return {"diarization": transcription}

--- a/backend/diarization/app/util.py
+++ b/backend/diarization/app/util.py
@@ -1,16 +1,50 @@
 import os
+import time
+import shutil
 
-CONFIG_DIR = "/diarization/config"
-DIARIZE_TMP_DIR = "/diarization/tmp"
-OUTPUT_DIR = os.path.join(CONFIG_DIR, 'oracle_vad')
+MAIN_DIR = os.path.join('diarization') 
+TMP_DIR = os.path.join(MAIN_DIR, 'tmp')
+
+timestamp = None
+
+CONFIG_DIR = None
+DIARIZE_TMP_DIR = None
+OUTPUT_DIR = None
+
+def initialize_dirs():
+    """
+    initialize all directories 
+    """ 
+    global timestamp, CONFIG_DIR, DIARIZE_TMP_DIR, OUTPUT_DIR
+
+    if timestamp is not None:
+        raise Exception("already initialized")
+    timestamp = time.time_ns()
+    CONFIG_DIR = os.path.join(MAIN_DIR, str(timestamp), 'config')
+    DIARIZE_TMP_DIR = os.path.join(MAIN_DIR, str(timestamp), 'tmp')
+    OUTPUT_DIR = os.path.join(CONFIG_DIR, 'oracle_vad')
+
+    os.makedirs(TMP_DIR, exist_ok=True)
+    os.makedirs(CONFIG_DIR, exist_ok=True)
+    os.makedirs(DIARIZE_TMP_DIR, exist_ok=True)
+    os.makedirs(OUTPUT_DIR, exist_ok=True)
+
+def delete_dirs():
+    """
+    this will delete ALL folders created in the MAIN_DIR and all of its content.
+    """ 
+    global timestamp, CONFIG_DIR, DIARIZE_TMP_DIR, OUTPUT_DIR
+    if timestamp is None:
+        raise Exception("nothing is initialized")
+    timestamp = None
+    shutil.rmtree(MAIN_DIR)
 
 def get_file_name(file_path):
     file_name, _ = os.path.splitext(os.path.basename(file_path))
     return file_name
 
 def get_rttm_path(file_name):
-    return f"{CONFIG_DIR}/oracle_vad/pred_rttms/{file_name}.rttm" # TODO make this nicer
+    return os.path.join(CONFIG_DIR, 'oracle_vad', 'pred_rttms', f"{file_name}.rttm")
 
 def get_wav_path(file_name):
-    file = file_name + ".wav"
-    return os.path.join(DIARIZE_TMP_DIR, file)
+    return os.path.join(DIARIZE_TMP_DIR, f"{file_name}.wav")

--- a/backend/diarization/app/util.py
+++ b/backend/diarization/app/util.py
@@ -1,0 +1,16 @@
+import os
+
+CONFIG_DIR = "/diarization/config"
+DIARIZE_TMP_DIR = "/diarization/tmp"
+OUTPUT_DIR = os.path.join(CONFIG_DIR, 'oracle_vad')
+
+def get_file_name(file_path):
+    file_name, _ = os.path.splitext(os.path.basename(file_path))
+    return file_name
+
+def get_rttm_path(file_name):
+    return f"{CONFIG_DIR}/oracle_vad/pred_rttms/{file_name}.rttm" # TODO make this nicer
+
+def get_wav_path(file_name):
+    file = file_name + ".wav"
+    return os.path.join(DIARIZE_TMP_DIR, file)


### PR DESCRIPTION
this PR solves issue #40.

now all diarization files that is not overwritten by reruns should now be removed after a diarization. This is all files on the format {filename}.txt, {filename}.rttm etc, except for two files in diarization/config/output_vad/vad_outputs, however these files will according to my testing be removed when starting a new analysis so no need to explicilty remove them.

all other files should either be needed for every analysis, our have a common name like inpu-manifest.json so they will be overwritten each iteration.