### PR TITLE
change from deleting MAIN_DIR to timestamp_dir

### DIFF
--- a/backend/diarization/app/main.py
+++ b/backend/diarization/app/main.py
@@ -13,7 +13,7 @@ async def diarize_media_file(json_data: str = Form(...), file: UploadFile = Form
     if transcription is None:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Transcription data not in request body") # TODO should this be a error?
 
-    ut.initialize_dirs()
+    timestamp = ut.initialize_dirs()
 
     file_path = os.path.join(ut.TMP_DIR, file.filename)
 
@@ -28,7 +28,7 @@ async def diarize_media_file(json_data: str = Form(...), file: UploadFile = Form
     except Exception:
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Diarization error.")
     finally:
-        ut.delete_dirs()
+        ut.delete_dirs(timestamp)
 
     return {"diarization": transcription}
     

--- a/backend/diarization/app/util.py
+++ b/backend/diarization/app/util.py
@@ -5,8 +5,6 @@ import shutil
 MAIN_DIR = os.path.join('diarization') 
 TMP_DIR = os.path.join(MAIN_DIR, 'tmp')
 
-timestamp = None
-
 CONFIG_DIR = None
 DIARIZE_TMP_DIR = None
 OUTPUT_DIR = None
@@ -15,11 +13,9 @@ def initialize_dirs():
     """
     initialize all directories 
     """ 
-    global timestamp, CONFIG_DIR, DIARIZE_TMP_DIR, OUTPUT_DIR
+    global CONFIG_DIR, DIARIZE_TMP_DIR, OUTPUT_DIR
 
-    if timestamp is not None:
-        raise Exception("already initialized")
-    timestamp = time.time_ns()
+    timestamp = time.time_ns() # using a timestamp is not guaranteed to give unique identifiers but works for now
     CONFIG_DIR = os.path.join(MAIN_DIR, str(timestamp), 'config')
     DIARIZE_TMP_DIR = os.path.join(MAIN_DIR, str(timestamp), 'tmp')
     OUTPUT_DIR = os.path.join(CONFIG_DIR, 'oracle_vad')
@@ -28,16 +24,14 @@ def initialize_dirs():
     os.makedirs(CONFIG_DIR, exist_ok=True)
     os.makedirs(DIARIZE_TMP_DIR, exist_ok=True)
     os.makedirs(OUTPUT_DIR, exist_ok=True)
+    return timestamp
 
-def delete_dirs():
+def delete_dirs(timestamp):
     """
     this will delete ALL folders created in the MAIN_DIR and all of its content.
     """ 
-    global timestamp, CONFIG_DIR, DIARIZE_TMP_DIR, OUTPUT_DIR
-    if timestamp is None:
-        raise Exception("nothing is initialized")
-    timestamp = None
-    shutil.rmtree(MAIN_DIR)
+    global CONFIG_DIR, DIARIZE_TMP_DIR, OUTPUT_DIR
+    shutil.rmtree(os.path.join(MAIN_DIR, str(timestamp)))
 
 def get_file_name(file_path):
     file_name, _ = os.path.splitext(os.path.basename(file_path))


### PR DESCRIPTION
I was a little quick and realised that deleting the MAIN_DIR is probably a bad idea, so changed it to deleting the timestamp dir. Is probably not thread safe but works for now when we have sequential evaluation (i believe time.time_ns() can return the same value if two executions is done sequentially calling on it)